### PR TITLE
Refactor(ui): complete Material icons migration in settings

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -6,7 +6,7 @@
 - Architecture follows `presentation -> domain -> data` with `get_it` + `provider`.
 - Multi-platform targets in repo: Android, Linux, macOS, Windows, Web.
 - Chat stack is decomposed into orchestrators plus focused cluster modules.
-- Material icon migration in UI/tests is mostly on `Symbols.*` (`material_symbols_icons`), with a small remaining `Icons.*` usage in notifications settings UI.
+- Material icon migration in UI is complete on `Symbols.*` (`material_symbols_icons`).
 - Theme system follows Material You (MD3): user-controlled theme mode, dynamic color toggle, AMOLED dark toggle, brand color seeds, contrast level, and responsive window size classes.
 
 ## Folder Structure

--- a/lib/presentation/pages/settings/sections/behavior_settings_section.dart
+++ b/lib/presentation/pages/settings/sections/behavior_settings_section.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:provider/provider.dart';
 
 import '../../../../core/constants/app_constants.dart';
@@ -160,7 +161,7 @@ class _BehaviorSettingsSectionState extends State<BehaviorSettingsSection> {
                       : () => unawaited(
                           settingsProvider.refreshOpenCodeBackedDefaults(),
                         ),
-                  icon: const Icon(Icons.refresh),
+                  icon: const Icon(Symbols.refresh),
                 ),
               ],
             ),
@@ -277,7 +278,7 @@ class _BehaviorSettingsSectionState extends State<BehaviorSettingsSection> {
                   onPressed: settingsProvider.openCodeDefaultsLoading
                       ? null
                       : () => unawaited(_applyUsername(context)),
-                  icon: const Icon(Icons.save),
+                  icon: const Icon(Symbols.save),
                   label: const Text('Save username'),
                 ),
               ),

--- a/lib/presentation/pages/settings/sections/notifications_settings_section.dart
+++ b/lib/presentation/pages/settings/sections/notifications_settings_section.dart
@@ -341,9 +341,9 @@ class _NotificationsSettingsSectionState
       null => Theme.of(context).colorScheme.onSurfaceVariant,
     };
     final statusIcon = switch (status) {
-      true => Icons.check_circle_outline,
-      false => Icons.warning_amber_rounded,
-      null => Icons.help_outline,
+      true => Symbols.check_circle,
+      false => Symbols.warning,
+      null => Symbols.help,
     };
     final statusText = switch (status) {
       true => 'Battery optimization is disabled for CodeWalk.',


### PR DESCRIPTION
This PR completes the ongoing effort to migrate UI icons from Flutter's default `Icons.*` to `Symbols.*` using `material_symbols_icons`. This ensures visual consistency across the entire application and eliminates the remaining technical debt explicitly noted in `CODEBASE.md`. 

The changes are limited to exactly what was required to finalize this migration, specifically in the `behavior_settings_section.dart` and `notifications_settings_section.dart` files. `CODEBASE.md` was also updated to correctly reflect that this migration task is now finished. No unnecessary dependencies or unrelated changes were introduced.

---
*PR created automatically by Jules for task [10390768528355914797](https://jules.google.com/task/10390768528355914797) started by @insign*