### PR TITLE
fix: add missing mounted check before reading context in chat page lifecycle

### DIFF
--- a/lib/presentation/pages/chat_page/chat_page_lifecycle.dart
+++ b/lib/presentation/pages/chat_page/chat_page_lifecycle.dart
@@ -464,6 +464,7 @@ extension _ChatPageLifecycle on _ChatPageState {
         );
       }
     }
+    if (!mounted) return;
     final projectProvider = context.read<ProjectProvider>();
     await projectProvider.onServerScopeChanged();
     await _chatProvider?.onServerScopeChanged();


### PR DESCRIPTION
This PR adds an `if (!mounted) return;` check before accessing `context.read<ProjectProvider>()` inside `_handleServerScopeChange` after an asynchronous gap. This is useful because it prevents runtime exceptions that would crash the app if the user leaves the chat page before the asynchronous task finishes, and it resolves a static analyzer warning.

### Quais arquivos foram alterados
* `lib/presentation/pages/chat_page/chat_page_lifecycle.dart`

### Arquivos .md e testes
* Nenhum arquivo `.md` foi atualizado pois a mudança não altera comportamento ou documentação arquitetural.
* Nenhum teste precisou ser atualizado ou adicionado porque é apenas um safety check de lifecycle do Flutter, que não quebra nenhum fluxo da suite de testes. Foi executado o test suite (`make check-fast`) que garantiu a não-regressão.

---
*PR created automatically by Jules for task [17573674378857327090](https://jules.google.com/task/17573674378857327090) started by @insign*