### PR TITLE
feat: add Flutter localization foundation

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,4 @@
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-dir: lib/l10n/generated
+output-localization-file: app_localizations.dart

--- a/lib/domain/entities/experience_settings.dart
+++ b/lib/domain/entities/experience_settings.dart
@@ -586,6 +586,7 @@ class ExperienceSettings {
       keepMobileRealtimeForShortPeriod: true,
       enableExperimentalMultiDeviceSync: false,
       themeMode: ThemeModeOption.system,
+      preferredLocaleTag: null,
       themePreset: null,
       useAmoledDark: false,
       useDynamicColor: true,
@@ -630,6 +631,7 @@ class ExperienceSettings {
     required this.keepMobileRealtimeForShortPeriod,
     this.enableExperimentalMultiDeviceSync = false,
     this.themeMode = ThemeModeOption.system,
+    this.preferredLocaleTag,
     this.themePreset,
     this.useAmoledDark = false,
     this.useDynamicColor = true,
@@ -674,6 +676,7 @@ class ExperienceSettings {
   final bool keepMobileRealtimeForShortPeriod;
   final bool enableExperimentalMultiDeviceSync;
   final ThemeModeOption themeMode;
+  final String? preferredLocaleTag;
   final OpenCodeThemePreset? themePreset;
   final bool useAmoledDark;
   final bool useDynamicColor;
@@ -718,6 +721,7 @@ class ExperienceSettings {
     bool? keepMobileRealtimeForShortPeriod,
     bool? enableExperimentalMultiDeviceSync,
     ThemeModeOption? themeMode,
+    String? Function()? preferredLocaleTag,
     OpenCodeThemePreset? Function()? themePreset,
     bool? useAmoledDark,
     bool? useDynamicColor,
@@ -773,6 +777,9 @@ class ExperienceSettings {
           enableExperimentalMultiDeviceSync ??
           this.enableExperimentalMultiDeviceSync,
       themeMode: themeMode ?? this.themeMode,
+      preferredLocaleTag: preferredLocaleTag != null
+          ? preferredLocaleTag()
+          : this.preferredLocaleTag,
       themePreset: themePreset != null ? themePreset() : this.themePreset,
       useAmoledDark: useAmoledDark ?? this.useAmoledDark,
       useDynamicColor: useDynamicColor ?? this.useDynamicColor,
@@ -860,6 +867,7 @@ class ExperienceSettings {
       'keepMobileRealtimeForShortPeriod': keepMobileRealtimeForShortPeriod,
       'enableExperimentalMultiDeviceSync': enableExperimentalMultiDeviceSync,
       'themeMode': themeModeOptionKey(themeMode),
+      if (preferredLocaleTag != null) 'preferredLocaleTag': preferredLocaleTag,
       if (themePreset != null)
         'themePreset': openCodeThemePresetKey(themePreset!),
       'useAmoledDark': useAmoledDark,
@@ -922,6 +930,7 @@ class ExperienceSettings {
         defaults.keepMobileRealtimeForShortPeriod;
     var enableExperimentalMultiDeviceSync =
         defaults.enableExperimentalMultiDeviceSync;
+    var preferredLocaleTag = defaults.preferredLocaleTag;
     var speechToTextEngine = defaults.speechToTextEngine;
     var speechSilenceTimeoutSeconds = defaults.speechSilenceTimeoutSeconds;
     var sherpaLanguageCode = defaults.sherpaLanguageCode;
@@ -1142,6 +1151,12 @@ class ExperienceSettings {
       themeMode = themeModeOptionFromKey(themeModeJson.trim().toLowerCase());
     }
 
+    final preferredLocaleTagJson = json['preferredLocaleTag'];
+    if (preferredLocaleTagJson is String &&
+        preferredLocaleTagJson.trim().isNotEmpty) {
+      preferredLocaleTag = preferredLocaleTagJson.trim();
+    }
+
     var themePreset = defaults.themePreset;
     final themePresetJson = json['themePreset'];
     if (themePresetJson is String && themePresetJson.trim().isNotEmpty) {
@@ -1262,6 +1277,7 @@ class ExperienceSettings {
       keepMobileRealtimeForShortPeriod: keepMobileRealtimeForShortPeriod,
       enableExperimentalMultiDeviceSync: enableExperimentalMultiDeviceSync,
       themeMode: themeMode,
+      preferredLocaleTag: preferredLocaleTag,
       themePreset: themePreset,
       useAmoledDark: useAmoledDark,
       useDynamicColor: useDynamicColor,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,4 @@
+{
+  "@@locale": "en",
+  "appLanguageLabel": "Language"
+}

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1,0 +1,4 @@
+{
+  "@@locale": "zh",
+  "appLanguageLabel": "语言"
+}

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1,0 +1,140 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'app_localizations_en.dart';
+import 'app_localizations_zh.dart';
+
+// ignore_for_file: type=lint
+
+/// Callers can lookup localized strings with an instance of AppLocalizations
+/// returned by `AppLocalizations.of(context)`.
+///
+/// Applications need to include `AppLocalizations.delegate()` in their app's
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
+///
+/// ```dart
+/// import 'generated/app_localizations.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: AppLocalizations.localizationsDelegates,
+///   supportedLocales: AppLocalizations.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```yaml
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # Rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the AppLocalizations.supportedLocales
+/// property.
+abstract class AppLocalizations {
+  AppLocalizations(String locale)
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static AppLocalizations? of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations);
+  }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('en'),
+    Locale('zh'),
+  ];
+
+  /// No description provided for @appLanguageLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Language'**
+  String get appLanguageLabel;
+}
+
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  Future<AppLocalizations> load(Locale locale) {
+    return SynchronousFuture<AppLocalizations>(lookupAppLocalizations(locale));
+  }
+
+  @override
+  bool isSupported(Locale locale) =>
+      <String>['en', 'zh'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}
+
+AppLocalizations lookupAppLocalizations(Locale locale) {
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'en':
+      return AppLocalizationsEn();
+    case 'zh':
+      return AppLocalizationsZh();
+  }
+
+  throw FlutterError(
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
+}

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1,0 +1,13 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for English (`en`).
+class AppLocalizationsEn extends AppLocalizations {
+  AppLocalizationsEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get appLanguageLabel => 'Language';
+}

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -1,0 +1,13 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Chinese (`zh`).
+class AppLocalizationsZh extends AppLocalizations {
+  AppLocalizationsZh([String locale = 'zh']) : super(locale);
+
+  @override
+  String get appLanguageLabel => '语言';
+}

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/widgets.dart';
+
+import 'generated/app_localizations.dart';
+
+String? appLocaleToTag(Locale? locale) {
+  if (locale == null) {
+    return null;
+  }
+  final languageCode = locale.languageCode.trim();
+  final countryCode = locale.countryCode?.trim();
+  if (languageCode.isEmpty) {
+    return null;
+  }
+  if (countryCode == null || countryCode.isEmpty) {
+    return languageCode;
+  }
+  return '$languageCode-$countryCode';
+}
+
+Locale? appLocaleFromTag(String? localeTag) {
+  final normalized = localeTag?.trim().replaceAll('_', '-').toLowerCase();
+  if (normalized == null || normalized.isEmpty) {
+    return null;
+  }
+  for (final locale in AppLocalizations.supportedLocales) {
+    if (appLocaleToTag(locale)?.toLowerCase() == normalized) {
+      return locale;
+    }
+    if (locale.languageCode.toLowerCase() == normalized) {
+      return locale;
+    }
+  }
+  return null;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,14 +3,16 @@ import 'dart:async';
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:window_manager/window_manager.dart';
 
 import 'core/constants/app_constants.dart';
-import 'domain/entities/experience_settings.dart';
 import 'core/di/injection_container.dart' as di;
 import 'core/logging/app_logger.dart';
+import 'domain/entities/experience_settings.dart';
+import 'l10n/generated/app_localizations.dart';
 import 'presentation/pages/app_shell_page.dart';
 import 'presentation/providers/app_provider.dart';
 import 'presentation/providers/chat_provider.dart';
@@ -22,37 +24,32 @@ import 'presentation/theme/app_theme.dart';
 import 'presentation/theme/opencode_theme_presets.dart';
 
 void main() {
-  runZonedGuarded(
-    () async {
-      WidgetsFlutterBinding.ensureInitialized();
-      AppLogger.installGlobalHandlers();
+  runZonedGuarded(() async {
+    WidgetsFlutterBinding.ensureInitialized();
+    AppLogger.installGlobalHandlers();
 
-      await SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
-      SystemChrome.setSystemUIOverlayStyle(
-        const SystemUiOverlayStyle(
-          statusBarColor: Colors.transparent,
-          systemNavigationBarColor: Colors.transparent,
-          systemNavigationBarDividerColor: Colors.transparent,
-        ),
-      );
+    await SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+    SystemChrome.setSystemUIOverlayStyle(
+      const SystemUiOverlayStyle(
+        statusBarColor: Colors.transparent,
+        systemNavigationBarColor: Colors.transparent,
+        systemNavigationBarDividerColor: Colors.transparent,
+      ),
+    );
 
-      if (_isDesktopRuntime()) {
-        await windowManager.ensureInitialized();
-      }
+    if (_isDesktopRuntime()) {
+      await windowManager.ensureInitialized();
+    }
 
-      if (_isAndroidRuntime()) {
-        await AndroidBackgroundAlertWorker.syncRegistrationFromPersistedSettings();
-      }
+    if (_isAndroidRuntime()) {
+      await AndroidBackgroundAlertWorker.syncRegistrationFromPersistedSettings();
+    }
 
-      // Initialize dependency injection
-      await di.init();
+    // Initialize dependency injection
+    await di.init();
 
-      runApp(const MyApp());
-    },
-    (error, stackTrace) {
-      AppLogger.recordZoneError(error, stackTrace);
-    },
-  );
+    runApp(const MyApp());
+  }, AppLogger.recordZoneError);
 }
 
 class MyApp extends StatelessWidget {
@@ -119,7 +116,7 @@ class MyApp extends StatelessWidget {
 
               // Use dynamic platform colors when available and enabled
               final lightScheme = usePresetSchemes
-                  ? presetLightScheme!
+                  ? presetLightScheme
                   : useDynamic && lightDynamic != null
                   ? lightDynamic
                   : ColorScheme.fromSeed(
@@ -128,7 +125,7 @@ class MyApp extends StatelessWidget {
                       contrastLevel: contrastLevel,
                     );
               final darkScheme = usePresetSchemes
-                  ? presetDarkScheme!
+                  ? presetDarkScheme
                   : useDynamic && darkDynamic != null
                   ? darkDynamic
                   : ColorScheme.fromSeed(
@@ -158,6 +155,14 @@ class MyApp extends StatelessWidget {
               };
               return MaterialApp(
                 title: AppConstants.appName,
+                locale: settingsProvider.preferredLocale,
+                localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
+                  AppLocalizations.delegate,
+                  GlobalMaterialLocalizations.delegate,
+                  GlobalWidgetsLocalizations.delegate,
+                  GlobalCupertinoLocalizations.delegate,
+                ],
+                supportedLocales: AppLocalizations.supportedLocales,
                 theme: AppTheme.lightFrom(
                   lightScheme,
                   appDensity: appDensity,

--- a/lib/presentation/providers/settings_provider.dart
+++ b/lib/presentation/providers/settings_provider.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart' show Locale;
 import 'package:open_filex/open_filex.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path_provider/path_provider.dart';
@@ -14,6 +15,7 @@ import '../../data/datasources/app_local_datasource.dart';
 import '../../data/models/agent_model.dart';
 import '../../data/models/provider_model.dart';
 import '../../domain/entities/experience_settings.dart';
+import '../../l10n/l10n.dart';
 import '../services/android_background_alert_logic.dart';
 import '../services/android_background_alert_worker.dart';
 import '../services/android_foreground_monitor_service.dart';
@@ -139,6 +141,8 @@ class SettingsProvider extends ChangeNotifier {
   List<String> get openCodeDefaultAgentOptions =>
       List<String>.unmodifiable(_openCodeDefaultAgentOptions);
   ThemeModeOption get themeMode => _settings.themeMode;
+  String? get preferredLocaleTag => _settings.preferredLocaleTag;
+  Locale? get preferredLocale => appLocaleFromTag(_settings.preferredLocaleTag);
   bool get useAmoledDark => _settings.useAmoledDark;
   bool get useDynamicColor => _settings.useDynamicColor;
   int? get customColorSeed => _settings.customColorSeed;
@@ -440,6 +444,19 @@ class SettingsProvider extends ChangeNotifier {
       return;
     }
     _settings = _settings.copyWith(themeMode: mode);
+    notifyListeners();
+    await _persist();
+  }
+
+  Future<void> setPreferredLocaleTag(String? localeTag) async {
+    final normalizedTag = localeTag?.trim();
+    final nextTag = (normalizedTag == null || normalizedTag.isEmpty)
+        ? null
+        : appLocaleToTag(appLocaleFromTag(normalizedTag));
+    if (_settings.preferredLocaleTag == nextTag) {
+      return;
+    }
+    _settings = _settings.copyWith(preferredLocaleTag: () => nextTag);
     notifyListeners();
     await _persist();
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -414,6 +414,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_markdown_plus:
     dependency: "direct main"
     description:
@@ -560,6 +565,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.3.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -66,6 +68,7 @@ dependencies:
   
   # JSON serialization
   json_annotation: ^4.8.1
+  intl: ^0.20.2
   
   # Equatable for value equality
   equatable: ^2.0.5
@@ -122,6 +125,7 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
+  generate: true
 
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in

--- a/test/unit/providers/settings_provider_test.dart
+++ b/test/unit/providers/settings_provider_test.dart
@@ -151,6 +151,26 @@ void main() {
       expect(settingsJson['composerAutoApprovePermissions'], isFalse);
     });
 
+    test('persists preferred locale selection', () async {
+      final local = InMemoryAppLocalDataSource();
+      final provider = SettingsProvider(
+        localDataSource: local,
+        dioClient: DioClient(),
+        soundService: _FakeSoundService(),
+      );
+
+      await provider.initialize();
+      await provider.setPreferredLocaleTag('zh');
+
+      expect(provider.preferredLocaleTag, 'zh');
+      expect(provider.preferredLocale?.languageCode, 'zh');
+
+      final raw = local.experienceSettingsJson;
+      expect(raw, isNotNull);
+      final settingsJson = jsonDecode(raw!) as Map<String, dynamic>;
+      expect(settingsJson['preferredLocaleTag'], 'zh');
+    });
+
     test('persists pending post-onboarding chat tour flag', () async {
       final local = InMemoryAppLocalDataSource();
       final first = SettingsProvider(


### PR DESCRIPTION
## Summary
- add Flutter localization scaffolding with generated delegates and baseline English/Chinese ARB files
- persist a preferred app locale in experience settings and expose it through `SettingsProvider`
- wire the root `MaterialApp` to use the generated localization delegates and supported locales

## Notes
- this PR intentionally stays small and does not add a language picker UI yet
- the goal is to land the localization foundation first so follow-up UI work can build on a clean base

## Validation
- `/workspace/usr/local/flutter/bin/flutter pub get`
- `/workspace/usr/local/flutter/bin/flutter gen-l10n`
- `/workspace/usr/local/flutter/bin/dart run build_runner build --delete-conflicting-outputs`
- `/workspace/usr/local/flutter/bin/flutter analyze --no-fatal-infos --no-fatal-warnings`
- `bash tool/ci/check_analyze_budget.sh /tmp/flutter_analyze_i18n.log 186`
- `timeout --foreground 5m /workspace/usr/local/flutter/bin/flutter test --no-pub --fail-fast`
